### PR TITLE
chore: enlarge buffer size for avoiding tracer discarded

### DIFF
--- a/tracetools_trace/tracetools_trace/tools/lttng_impl.py
+++ b/tracetools_trace/tracetools_trace/tools/lttng_impl.py
@@ -151,10 +151,10 @@ def setup(
         channel_ust.name = channel_name_ust
         # Discard, do not overwrite
         channel_ust.attr.overwrite = 0
-        # 2 sub-buffers of 32 times the usual page size
+        # 2 sub-buffers of 256 times the usual page size
         # We use 2 sub-buffers because the number of sub-buffers is pointless in discard mode,
         # and switching between sub-buffers introduces noticeable CPU overhead
-        channel_ust.attr.subbuf_size = 32 * 4096
+        channel_ust.attr.subbuf_size = 256 * 4096
         channel_ust.attr.num_subbuf = 2
         # Ignore switch timer interval and use read timer instead
         channel_ust.attr.switch_timer_interval = 0


### PR DESCRIPTION
Signed-off-by: takeshi.iwanari <takeshi.iwanari@tier4.jp>

## Description

- Enlarge buffer size from 32 x 4096 to 256 x 4096
- Reason
    - `ros2 caret record` takes very long time to start recording a huge application like Autoware in some ECU
    - `-f 100000` option shortens the time, but tracer discarded error happens

## Related links

None

## Notes for reviewers

I confirmed the increase of memory usage is small (64 MByte) with Autoware.
Since we use lttng.BUFFER_PER_UID, memory usage is calculated as ` (# of cores) x (buffer size) x 2`

## Pre-review checklist for the PR author

- [x] I've confirmed the [contribution guidelines](https://github.com/tier4/caret/blob/main/.github/CONTRIBUTING.md).
- [x] The PR is ready for review.

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR has been properly tested.
- [x] The PR has been reviewed.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.
