### PR TITLE
chore: remove dispatch_subscription_callback tracepoint

### DIFF
--- a/tracetools/include/tracetools/tp_call.h
+++ b/tracetools/include/tracetools/tp_call.h
@@ -442,23 +442,6 @@ TRACEPOINT_EVENT(
 
 TRACEPOINT_EVENT(
   TRACEPOINT_PROVIDER,
-  dispatch_subscription_callback,
-  TP_ARGS(
-    const void *, message_arg,
-    const void *, callback_arg,
-    const uint64_t, source_timestamp_arg,
-    const uint64_t, message_timestamp_arg
-  ),
-  TP_FIELDS(
-    ctf_integer_hex(const void *, message, message_arg)
-    ctf_integer_hex(const void *, callback, callback_arg)
-    ctf_integer(const uint64_t, source_stamp, source_timestamp_arg)
-    ctf_integer(const uint64_t, message_timestamp, message_timestamp_arg)
-  )
-)
-
-TRACEPOINT_EVENT(
-  TRACEPOINT_PROVIDER,
   dispatch_intra_process_subscription_callback,
   TP_ARGS(
     const void *, message_arg,

--- a/tracetools/include/tracetools/tracetools.h
+++ b/tracetools/include/tracetools/tracetools.h
@@ -496,13 +496,6 @@ DECLARE_TRACEPOINT(
   const uint64_t message_timestamp)
 
 DECLARE_TRACEPOINT(
-  dispatch_subscription_callback,
-  const void * message,
-  const void * callback,
-  const uint64_t source_timestamp,
-  const uint64_t message_timestamp)
-
-DECLARE_TRACEPOINT(
   dispatch_intra_process_subscription_callback,
   const void * message,
   const void * callback,

--- a/tracetools/src/tracetools.c
+++ b/tracetools/src/tracetools.c
@@ -390,21 +390,6 @@ void TRACEPOINT(
 }
 
 void TRACEPOINT(
-  dispatch_subscription_callback,
-  const void * message,
-  const void * callback,
-  const uint64_t source_stamp,
-  const uint64_t message_timestamp)
-{
-  CONDITIONAL_TP(
-    dispatch_subscription_callback,
-    message,
-    callback,
-    source_stamp,
-    message_timestamp);
-}
-
-void TRACEPOINT(
   dispatch_intra_process_subscription_callback,
   const void * message,
   const void * callback,

--- a/tracetools/src/tracetools.c
+++ b/tracetools/src/tracetools.c
@@ -379,8 +379,7 @@ void TRACEPOINT(
   rclcpp_intra_publish,
   const void * publisher_handle,
   const void * message,
-  const uint64_t message_timestamp
-  )
+  const uint64_t message_timestamp)
 {
   CONDITIONAL_TP(
     rclcpp_intra_publish,


### PR DESCRIPTION
# Description
By using rmw_take tracepoints to tie records in CARET, the `dispatch_subscription_callback` tracepoint is no longer a required tracepoint.
Unnecessary trace points must be deleted to prevent trace data from being lost.

# Related Links
- https://github.com/tier4/rclcpp/pull/1
- https://github.com/tier4/CARET_trace/pull/113
- https://github.com/tier4/CARET_analyze/pull/296

# Changes
- remove `dispatch_subscription_callback` tracepoint