### PR TITLE
feat: change publish trace point definition

### DIFF
--- a/tracetools/include/tracetools/tp_call.h
+++ b/tracetools/include/tracetools/tp_call.h
@@ -101,13 +101,11 @@ TRACEPOINT_EVENT(
   rclcpp_publish,
   TP_ARGS(
     const void *, publisher_handle_arg,
-    const void *, message_arg,
-    const uint64_t, message_timestamp_arg
+    const void *, message_arg
   ),
   TP_FIELDS(
     ctf_integer_hex(const void *, publisher_handle, publisher_handle_arg)
     ctf_integer_hex(const void *, message, message_arg)
-    ctf_integer(const uint64_t, message_timestamp, message_timestamp_arg)
   )
 )
 
@@ -430,13 +428,11 @@ TRACEPOINT_EVENT(
   rclcpp_intra_publish,
   TP_ARGS(
     const void *, publisher_handle_arg,
-    const void *, message_arg,
-    const uint64_t, message_timestamp_arg
+    const void *, message_arg
   ),
   TP_FIELDS(
     ctf_integer_hex(const void *, publisher_handle, publisher_handle_arg)
     ctf_integer_hex(const void *, message, message_arg)
-    ctf_integer(const uint64_t, message_timestamp, message_timestamp_arg)
   )
 )
 

--- a/tracetools/include/tracetools/tracetools.h
+++ b/tracetools/include/tracetools/tracetools.h
@@ -163,13 +163,11 @@ DECLARE_TRACEPOINT(
  *
  * \param[in] publisher_handle not used, but kept for API/ABI stability
  * \param[in] message pointer to the message being published
- * \param[in] timestamp of message header
  */
 DECLARE_TRACEPOINT(
   rclcpp_publish,
   const void * publisher_handle,
-  const void * message,
-  const uint64_t message_timestamp)
+  const void * message)
 
 /// `rcl_publish`
 /**
@@ -492,8 +490,7 @@ DECLARE_TRACEPOINT(
 DECLARE_TRACEPOINT(
   rclcpp_intra_publish,
   const void * publisher_handle,
-  const void * message,
-  const uint64_t message_timestamp)
+  const void * message)
 
 DECLARE_TRACEPOINT(
   dispatch_subscription_callback,

--- a/tracetools/src/tracetools.c
+++ b/tracetools/src/tracetools.c
@@ -376,8 +376,7 @@ void TRACEPOINT(
 void TRACEPOINT(
   rclcpp_intra_publish,
   const void * publisher_handle,
-  const void * message
-  )
+  const void * message)
 {
   CONDITIONAL_TP(
     rclcpp_intra_publish,

--- a/tracetools/src/tracetools.c
+++ b/tracetools/src/tracetools.c
@@ -97,14 +97,12 @@ void TRACEPOINT(
 void TRACEPOINT(
   rclcpp_publish,
   const void * publisher_handle,
-  const void * message,
-  const uint64_t message_timestamp)
+  const void * message)
 {
   CONDITIONAL_TP(
     rclcpp_publish,
     publisher_handle,
-    message,
-    message_timestamp);
+    message);
 }
 
 void TRACEPOINT(
@@ -378,15 +376,13 @@ void TRACEPOINT(
 void TRACEPOINT(
   rclcpp_intra_publish,
   const void * publisher_handle,
-  const void * message,
-  const uint64_t message_timestamp
+  const void * message
   )
 {
   CONDITIONAL_TP(
     rclcpp_intra_publish,
     publisher_handle,
-    message,
-    message_timestamp);
+    message);
 }
 
 void TRACEPOINT(


### PR DESCRIPTION
Some parts of the current CARET define their own trace points. For future development, information that is no longer needed (e.g. message_timestamp in rclcpp_publish) will be removed and the function signatures will be modified to match.