### PR TITLE
chore: adjust buffer size for avoiding tracer discarded and avoiding …

### DIFF
--- a/tracetools_trace/tracetools_trace/tools/lttng_impl.py
+++ b/tracetools_trace/tracetools_trace/tools/lttng_impl.py
@@ -151,10 +151,10 @@ def setup(
         channel_ust.name = channel_name_ust
         # Discard, do not overwrite
         channel_ust.attr.overwrite = 0
-        # 2 sub-buffers of 256 times the usual page size
+        # 2 sub-buffers of 128 times the usual page size
         # We use 2 sub-buffers because the number of sub-buffers is pointless in discard mode,
         # and switching between sub-buffers introduces noticeable CPU overhead
-        channel_ust.attr.subbuf_size = 256 * 4096
+        channel_ust.attr.subbuf_size = 128 * 4096
         channel_ust.attr.num_subbuf = 2
         # Ignore switch timer interval and use read timer instead
         channel_ust.attr.switch_timer_interval = 0


### PR DESCRIPTION
…lack of trace data in Docker

Signed-off-by: takeshi.iwanari <takeshi.iwanari@tier4.jp>

## Description

- Decrease buffer size from 256 x 4096 to 128 x 4096
- Reason
    - Issue described in [this PR](https://github.com/tier4/ros2_tracing/pull/3) was fixed by [this PR](https://github.com/tier4/CARET_trace/pull/129)
    - Huge buffer size like 256 x 4096 causes [another problem that only meta data is recorded](https://github.com/tier4/CARET_trace/pull/129)

## Related links

[None](https://tier4.atlassian.net/browse/RT2-898)

## Notes for reviewers

None

## Pre-review checklist for the PR author

- [x] I've confirmed the [contribution guidelines](https://github.com/tier4/caret/blob/main/.github/CONTRIBUTING.md).
- [x] The PR is ready for review.

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.
